### PR TITLE
Force -source 1.8 and -target 1.8 for Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,4 +15,8 @@
   		<version>1.3.1</version>
   	</dependency>
   </dependencies>
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
 </project>


### PR DESCRIPTION
We use features in recent versions of Java, so we must force Maven to build against a recent enough version.