### PR TITLE
Add in css classes for titled connection skins that are diffed or hidden

### DIFF
--- a/src/main/resources/titledskins.css
+++ b/src/main/resources/titledskins.css
@@ -173,3 +173,11 @@
 .att-style6 {
     -fx-background-color: crimson;    	
 }
+
+.titled-connection-diff {
+  -fx-stroke: crimson;
+}
+
+.titled-connection-hidden {
+  -fx-opacity: 0.1;
+}


### PR DESCRIPTION
We could factor out the classes later into more options for the colour key suggested.